### PR TITLE
Support annotated companions.

### DIFF
--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -330,9 +330,9 @@ class TypeClassMacros(val c: Context) {
         ops ++ allOps
       }
 
-      val q"object $name extends ..$bases { ..$body }" = comp
+      val q"$mods object $name extends ..$bases { ..$body }" = comp
       val companion = q"""
-        object $name extends ..$bases {
+        $mods object $name extends ..$bases {
           ..$body
           $summoner
           ..$opsMembers

--- a/core/src/test/scala/simulacrum/typeclass.scala
+++ b/core/src/test/scala/simulacrum/typeclass.scala
@@ -284,5 +284,11 @@ class TypeClassTest extends WordSpec with Matchers {
         Option(Option(1)).bar
       }
     }
+
+    "support annotated companions" in {
+      class exports extends scala.annotation.StaticAnnotation
+      @typeclass trait Foo[F[_]]
+      @exports object Foo
+    }
   }
 }


### PR DESCRIPTION
Currently annotated companions will result in a MatchError at compile time in `generateCompanion`.