### PR TITLE
Revert imp integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val commonSettings = Seq(
   ),
   libraryDependencies ++= Seq(
     "org.scalatest" %%% "scalatest" % "3.0.0-M7" % "test",
-    "org.spire-math" %% "imp" % "0.2.0"
+    "org.spire-math" %% "imp" % "0.2.0" % "provided"
   ),
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
   licenses += ("Three-clause BSD-style", url("https://github.com/mpilquist/simulacrum/blob/master/LICENSE")),

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,7 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("snapshots")
   ),
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.0.0-M7" % "test",
-    "org.spire-math" %% "imp" % "0.2.0" % "provided"
+    "org.scalatest" %%% "scalatest" % "3.0.0-M7" % "test"
   ),
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
   licenses += ("Three-clause BSD-style", url("https://github.com/mpilquist/simulacrum/blob/master/LICENSE")),
@@ -145,3 +144,4 @@ lazy val noPublishSettings = Seq(
   publishLocal := (),
   publishArtifact := false
 )
+

--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val examplesJS = examples.js
 // Base Build Settings
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
   ),
   libraryDependencies ++= {

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -298,7 +298,7 @@ class TypeClassMacros(val c: Context) {
 
     def generateCompanion(typeClass: ClassDef, tparam0: TypeDef, proper: Boolean, comp: Tree) = {
       val tparam = eliminateVariance(tparam0)
-      val summoner = q"def apply[$tparam](implicit instance: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] = instance"
+      val summoner = q"@inline def apply[$tparam](implicit instance: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] = instance"
 
       val liftedTypeArg = if (proper) None else Some {
         // We have a TypeClass[F[_ >: L <: U]], so let's create a F[X >: L <: U] for a fresh name X

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -6,7 +6,6 @@ import scala.reflect.macros.whitebox.Context
 
 import macrocompat._
 
-
 /**
  * Annotation that may be applied to methods on a type that is annotated with `@typeclass`.
  *
@@ -299,17 +298,7 @@ class TypeClassMacros(val c: Context) {
 
     def generateCompanion(typeClass: ClassDef, tparam0: TypeDef, proper: Boolean, comp: Tree) = {
       val tparam = eliminateVariance(tparam0)
-
-      // The apply method uses the imp macro to summon the appropriate instance, but as imp is a
-      // macro itself, an import is required in the generated tree to allow the macro to be called
-      // in the generated tree.
-      val summonerImports = q"""
-        import scala.language.experimental.macros
-        """
-
-      val summoner = q"""
-        def apply[$tparam](implicit ev: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] =
-          macro imp.summon[${typeClass.name}[${tparam.name}]]"""
+      val summoner = q"def apply[$tparam](implicit instance: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] = instance"
 
       val liftedTypeArg = if (proper) None else Some {
         // We have a TypeClass[F[_ >: L <: U]], so let's create a F[X >: L <: U] for a fresh name X
@@ -370,7 +359,6 @@ class TypeClassMacros(val c: Context) {
       val companion = q"""
         $mods object $name extends ..$bases {
           ..$body
-          $summonerImports
           $summoner
           ..$opsMembers
         }


### PR DESCRIPTION
This PR reverts integration with imp, in order to remove the need for any dependencies on projects compiled with simulacrum.

Due to the imp integration, projects that use a library compiled with simulacrum required imp on the compile time class path. We can revisit macro based optimizations, like those done in imp and machinist, as part of typeclassic.

Sorry I didn't spot this sooner @mikejcurry!