### PR TITLE
Qualify `@inline` to work with `-Yno-imports`.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,8 @@ lazy val core = crossProject.crossType(CrossType.Pure)
   .settings(commonSettings: _*)
   .settings(
     moduleName := "simulacrum",
-    libraryDependencies += "org.typelevel" %% "macro-compat" % "1.1.1"
+    libraryDependencies += "org.typelevel" %% "macro-compat" % "1.1.1",
+    scalacOptions in (Test) += "-Yno-imports"
   )
   .settings(scalaMacroDependencies:_*)
   .jsSettings(

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -302,7 +302,7 @@ class TypeClassMacros(val c: Context) {
 
     def generateCompanion(typeClass: ClassDef, tparam0: TypeDef, proper: Boolean, comp: Tree) = {
       val tparam = eliminateVariance(tparam0)
-      val summoner = q"@inline def apply[$tparam](implicit instance: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] = instance"
+      val summoner = q"@scala.inline def apply[$tparam](implicit instance: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] = instance"
 
       val liftedTypeArg = if (proper) None else Some {
         // We have a TypeClass[F[_ >: L <: U]], so let's create a F[X >: L <: U] for a fresh name X

--- a/core/src/test/scala/simulacrum/jvm.scala
+++ b/core/src/test/scala/simulacrum/jvm.scala
@@ -2,6 +2,11 @@ package simulacrum
 
 import org.scalatest.{ WordSpec, Matchers }
 
+// NB: These imports are because the tests are compiled with `-Yno-imports`, to
+//     ensure that simulacrum works in projects that use that flag.
+import scala.Int
+import scala.collection.immutable.List
+
 class JvmTypeClassTest extends WordSpec with Matchers {
   "the @typeclass annotation" should {
     "generate serializable traits by default" in {

--- a/core/src/test/scala/simulacrum/typeclass.scala
+++ b/core/src/test/scala/simulacrum/typeclass.scala
@@ -2,6 +2,14 @@ package simulacrum
 
 import org.scalatest.{ WordSpec, Matchers }
 
+// NB: These imports are because the tests are compiled with `-Yno-imports`, to
+//     ensure that simulacrum works in projects that use that flag.
+import java.lang.String
+import scala.{ Any, Boolean, Either, Int, Left, Nil, Option, Right, Some }
+import scala.Predef.{ ???, ArrowAssoc, identity, wrapString }
+import scala.collection.immutable.List
+import scala.util
+
 @typeclass trait Semigroup[T] {
   @op("|+|", alias = true)
   def append(x: T, y: T): T
@@ -124,7 +132,6 @@ class TypeClassTest extends WordSpec with Matchers {
           def append(x: Int, y: Int) = x + y
         }
 
-        import Sg.ops._
         "1 append 2 shouldBe 3" shouldNot compile
         "1 foo 2 shouldBe 3" shouldNot compile
       }


### PR DESCRIPTION
Also, use `-Yno-imports` in the tests to ensure this doesn’t regress.

At SlamData we use `-Yno-imports` everywhere, and I have to explicitly `import scala.inline` anywhere we define a `@typeclass`, even though we don’t reference `@inline`.