### PR TITLE
Fix typo which meant more parameters were needed and inference bug

### DIFF
--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -232,9 +232,9 @@ class TypeClassMacros(val c: Context) {
               original.updated(0, original(0).updated(0, replacement))
             }
 
-            rewriteSimpleArgs(args.tree)
+            val mtparamss = method.tparams.map(t => tq"""${t.name}""").map(rewriteSimpleArgs.transform)
 
-            val rhs = paramNamess.foldLeft(q"""$tcInstanceName.${method.name}""": Tree) { (tree, paramNames) =>
+            val rhs = paramNamess.foldLeft(q"""$tcInstanceName.${method.name}[..$mtparamss]""": Tree) { (tree, paramNames) =>
               Apply(tree, paramNames)
             }
 

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -234,7 +234,7 @@ class TypeClassMacros(val c: Context) {
 
             val mtparamss = method.tparams.map(t => tq"""${t.name}""").map(rewriteSimpleArgs.transform)
 
-            val rhs = paramNamess.foldLeft(q"""$tcInstanceName.${method.name}[..$mtparamss]""": Tree) { (tree, paramNames) =>
+            val rhs = paramNamess.foldLeft(q"""$tcInstanceName.${method.name.toTermName}[..$mtparamss]""": Tree) { (tree, paramNames) =>
               Apply(tree, paramNames)
             }
 

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -214,7 +214,7 @@ class TypeClassMacros(val c: Context) {
               ValDef(Modifiers(Flag.IMPLICIT), TermName(c.freshName("ev")), tEq, EmptyTree)
           }
           //params to strip from method signature because they are defined on 
-          val removeTParams = simpleArgs.foldLeft(List.empty[Name])((b, a) => a._2.map(_ :: b).getOrElse(b)).toSet
+          val removeTParams = simpleArgs.filter(_._4).map(_._2.get).toSet
           val withoutFirst = if (firstParamList.tail.isEmpty) method.vparamss.tail else firstParamList.tail :: method.vparamss.tail
           val withRewrittenFirst = withoutFirst map { _ map { param =>
             ValDef(param.mods, param.name, rewriteSimpleArgs.transform(param.tpt), rewriteSimpleArgs.transform(param.rhs))
@@ -232,11 +232,13 @@ class TypeClassMacros(val c: Context) {
               original.updated(0, original(0).updated(0, replacement))
             }
 
-            val rhs = paramNamess.foldLeft(Select(Ident(tcInstanceName), method.name): Tree) { (tree, paramNames) =>
+            rewriteSimpleArgs(args.tree)
+
+            val rhs = paramNamess.foldLeft(q"""$tcInstanceName.${method.name}""": Tree) { (tree, paramNames) =>
               Apply(tree, paramNames)
             }
 
-            val fixedTParams = method.tparams.filter { tparam => !simpleArgs.contains(tparam.name) }
+            val fixedTParams = method.tparams.filter { tparam => !removeTParams.contains(tparam.name) }
 
             determineOpsMethodName(method) map { name =>
               // Important: let the return type be inferred here, so the return type doesn't need to be rewritten

--- a/examples/src/test/scala/simulacrum/examples/examples.scala
+++ b/examples/src/test/scala/simulacrum/examples/examples.scala
@@ -120,7 +120,6 @@ class Examples extends WordSpec with Matchers {
       div(Maybe.just(1), Maybe.empty) shouldBe Maybe.empty
     }
 
-    //TODO: Move this shape out
     @typeclass trait Bifunctor[F[_, _]] {
       def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D]
       def first[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = bimap(fab)(f, identity)

--- a/examples/src/test/scala/simulacrum/examples/examples.scala
+++ b/examples/src/test/scala/simulacrum/examples/examples.scala
@@ -180,7 +180,7 @@ class Examples extends WordSpec with Matchers {
 
     "strip type arguments from ops" in {
       import Function1Strong._
-      (fab.first[String] apply (42 -> 1)) shouldBe ("World", "Hello")
+      (fab.first[String] apply (42 -> "Hello")) shouldBe ("World", "Hello")
     }
 
     "support using ops from unrelated type classes in the same scope" in {


### PR DESCRIPTION
#59 introduced a bug which added redundant type parameters on methods.

Fixed an inference issue which stopped methods such as `first[A, B, C]` working by explicitly adding the method arguments. 