### PR TITLE
Skip inference with higher kinds which have cast

### DIFF
--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -232,7 +232,7 @@ class TypeClassMacros(val c: Context) {
               original.updated(0, original(0).updated(0, replacement))
             }
 
-            val mtparamss = method.tparams.map(t => tq"""${t.name}""").map(rewriteSimpleArgs.transform)
+            val mtparamss = if(equalityEvidences.isEmpty) method.tparams.map(t => tq"""${t.name}""").map(rewriteSimpleArgs.transform) else Nil
 
             val rhs = paramNamess.foldLeft(q"""$tcInstanceName.${method.name.toTermName}[..$mtparamss]""": Tree) { (tree, paramNames) =>
               Apply(tree, paramNames)


### PR DESCRIPTION
Higher kinds don't play nice with the inference because of the fact that we cast from `F[C]` to `F[G[A]]`. 
I'm temporarily skipping these out while I think of a nicer way to cast in the inference case. 