### PR TITLE
Add support for dependent types to ops and summoner

### DIFF
--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -330,6 +330,7 @@ class TypeClassMacros(val c: Context) {
         c.error(c.enclosingPosition, s"@typeclass excludes unknown parent types: ${unknownParentExclusions.mkString}")
       }
       q"""trait AllOps[..$tparams] extends Ops[..$tparamNames] with ..$allOpsParents {
+        type TypeClassType <: ${typeClass.name}[${tparam.name}]
         val $tcInstanceName: TypeClassType
       }"""
     }

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -268,7 +268,11 @@ class TypeClassMacros(val c: Context) {
         tq"${typeClass.name}[${tparam.name}]"
       } else {
         val refinements = abstractTypeMembers.map { case TypeDef(mods, name, tparams, rhs) =>
-          TypeDef(NoMods, name, tparams, tq"$instance.$name")
+          val (namedParams, names) = tparams.map { case TypeDef(pmods, _, ptparams, prhs) =>
+            val newName = TypeName(c.freshName)
+            (TypeDef(pmods, newName, ptparams, prhs), newName)
+          }.unzip
+          TypeDef(NoMods, name, namedParams, tq"$instance.$name[..$names]")
         }
         tq"${typeClass.name}[${tparam.name}]{ ..$refinements }"
       }

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -339,7 +339,7 @@ class TypeClassMacros(val c: Context) {
       val tparam = eliminateVariance(tparam0)
       val instance = TermName("instance")
       val refinedType = refinedInstanceTypeTree(typeClass, tparam, instance)
-      val summoner = q"@scala.inline def apply[$tparam](implicit $instance: ${typeClass.name}[${tparam.name}]): $refinedType = instance"
+      val summoner = q"@scala.inline def apply[$tparam](implicit $instance: ${typeClass.name}[${tparam.name}]): $refinedType = $instance"
 
       val liftedTypeArgs = if (proper) List.empty[TypeDef] else {
         // We have a TypeClass[F[_ >: L <: U]], so let's create a F[X >: L <: U] for a fresh name X

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -388,7 +388,7 @@ class TypeClassMacros(val c: Context) {
           "org.wartremover.warts.ExplicitImplicitTypes",
           "org.wartremover.warts.ImplicitConversion"))
         implicit def $methodName[..$tparams](target: $targetType)(implicit $instance: ${typeClass.name}[${tparam.name}]): $opsType[..$tparamNames]{ type TypeClassType = $refinedType} =
-          new $opsType[..$tparamNames] { type TypeClassType = $refinedType; val self = target; val $tcInstanceName = $instance.asInstanceOf[$refinedType] }
+          new $opsType[..$tparamNames] { type TypeClassType = $refinedType; val self = target; val $tcInstanceName: TypeClassType = $instance }
         """
       }
 

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -332,7 +332,9 @@ class TypeClassMacros(val c: Context) {
 
     def generateCompanion(typeClass: ClassDef, tparam0: TypeDef, proper: Boolean, comp: Tree) = {
       val tparam = eliminateVariance(tparam0)
-      val summoner = q"@scala.inline def apply[$tparam](implicit instance: ${typeClass.name}[${tparam.name}]): ${typeClass.name}[${tparam.name}] = instance"
+      val instance = TermName("instance")
+      val refinedType = refinedInstanceTypeTree(typeClass, tparam, instance)
+      val summoner = q"@scala.inline def apply[$tparam](implicit $instance: ${typeClass.name}[${tparam.name}]): $refinedType = instance"
 
       val liftedTypeArgs = if (proper) List.empty[TypeDef] else {
         // We have a TypeClass[F[_ >: L <: U]], so let's create a F[X >: L <: U] for a fresh name X


### PR DESCRIPTION
Until now, if you had a typeclass like

```scala
@typeclass
trait First[P] {
  type Out
  def first(product: P): Out
}
```
the precise type of `Out` is not retained when calling `First[(String,Int)].first(("foo",42))` or `("foo",42).first`. Instead you get some existential type mumbo jumbo, which means you cannot do anything meaningful with those values.

This pull request slightly alters the encoding of typeclasses to support this. Given the above definition, something similar to the following is generated at compile time:

```scala
trait First[P] {
  type Out
  def first(product: P): Out
}

object First {
  def apply[A](implicit instance: First[A]): First[A] { type Out = instance.Out } = instance

  trait Ops[A] {
    type TypeClassType <: First[A]
    val typeClassInstance: TypeClassType
    import typeClassInstance._
    def self: A
    def first: Out = typeClassInstance.first(self)
  }

  trait ToFirstOps {
    implicit def toFirstOps[A](target: A)(implicit tc: First[A]): Ops[A] { type TypeClassType = First[A] { type Out = tc.Out } } = new Ops[A] {
      type TypeClassType = First[A] { type Out = tc.Out }
      val self = target
      val typeClassInstance: TypeClassType = tc
    }
  }

  object nonInheritedOps extends ToFirstOps

  trait AllOps[A] extends Ops[A] {
    type TypeClassType <: First[A]
    val typeClassInstance: TypeClassType
  }

  object ops {
    implicit def toAllFirstOps[A](target: A)(implicit tc: First[A]): AllOps[A] { type TypeClassType = First[A] { type Out = tc.Out } } = new AllOps[A] {
      type TypeClassType = First[A] { type Out = tc.Out }
      val self = target
      val typeClassInstance: TypeClassType = tc
    }
  }
}
```

Dependent type constructors are also supported. Example:

```scala
scala> :paste
// Entering paste mode (ctrl-D to finish)

import simulacrum.typeclass
@typeclass trait Mutable[S[_]] { type R[_]; def toMutable[A](source: S[A]): R[A] }
object Mutable {
  import scala.collection.mutable
  type Aux[S[_],R0[_]] = Mutable[S]{ type R[x] = R0[x] }
  implicit def converterImpl: Aux[List, mutable.ListBuffer] = new Mutable[List] {
    type R[x] = mutable.ListBuffer[x]
    def toMutable[A](s: List[A]) = s.to[mutable.ListBuffer]
  }
}

// Exiting paste mode, now interpreting.

import simulacrum.typeclass
defined trait Mutable
defined object Mutable

scala> import Mutable.ops._
import Mutable.ops._

scala> List(1,2,3).toMutable
res0: scala.collection.mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
```

And as an illustration of the problem being solved, if the above snippet is evaluated against master the result is this:

```scala
scala> List(1,2,3).toMutable
<console>:20: warning: inferred existential type _5.typeClassInstance.R[Int] forSome { val _5: Mutable.AllOps[List,Int] }, which cannot be expressed by wildcards,  should be enabled
by making the implicit value scala.language.existentials visible.
This can be achieved by adding the import clause 'import scala.language.existentials'
or by setting the compiler option -language:existentials.
See the Scaladoc for value scala.language.existentials for a discussion

why the feature should be explicitly enabled.
       List(1,2,3).toMutable
                   ^
res0: _5.typeClassInstance.R[Int] forSome { val _5: Mutable.AllOps[List,Int] } = ListBuffer(1, 2, 3)
```

If there is interest in merging this, I will add some tests and examples. (*do things that get tested in examples also need to be tested in test?)

This should close issues #72 and #71, and improve the fix for #21.