### PR TITLE
very simple presentation compiler test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,15 @@ lazy val core = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
     scalacOptions in (Test) += "-Yno-imports"
   )
   .settings(scalaMacroDependencies:_*)
+  .jvmSettings(
+    libraryDependencies += "org.ensime" %% "pcplod" % "1.2.1" % "test",
+    // WORKAROUND https://github.com/ensime/pcplod/issues/12
+    fork in Test := true,
+    javaOptions in Test ++= Seq(
+      s"""-Dpcplod.settings=${(scalacOptions in Test).value.filterNot(_.contains(",")).mkString(",")}""",
+      s"""-Dpcplod.classpath=${(fullClasspath in Test).value.map(_.data).mkString(",")}"""
+    )
+  )
   .jsSettings(
     excludeFilter in (Test, unmanagedSources) := "jvm.scala"
   )

--- a/core/.jvm/src/test/resources/example.scala
+++ b/core/.jvm/src/test/resources/example.scala
@@ -1,0 +1,9 @@
+package example
+
+import simulacrum._
+
+@typeclass trait Semigroup[T] {
+  @op("|+|", alias = true)
+  def ap@def1@pend(x: T, y: T): T
+  def appendCurried(x: T)(y: T): T = append(x, y)
+}

--- a/core/src/test/scala/simulacrum/pc.scala
+++ b/core/src/test/scala/simulacrum/pc.scala
@@ -1,0 +1,18 @@
+package simulacrum
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers._
+import org.scalatest.OptionValues._
+
+import org.ensime.pcplod._
+
+class PresentationCompilerTest extends WordSpec {
+  "the @typeclass annotation" should {
+    "not produce warnings" in withMrPlod("example.scala") { mr: MrPlod =>
+      mr.messages shouldBe 'empty
+
+      mr.typeAtPoint('def1).value shouldBe "T"
+    }
+  }
+}
+


### PR DESCRIPTION
This shows simulacrum breaking the presentation compiler: ensime, scala-ide, and any LSP that will come along between now and Scala 3.

Accepting this PR will add a dependency on your build (but not for downstream) that you might not want to accept because I can't guarantee releases for new versions of scala (especially not milestones).