### PR TITLE
Future proof subtype evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea/

--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -210,7 +210,7 @@ class TypeClassMacros(val c: Context) {
           //evidence for type args which are nested
           val equalityEvidences = simpleArgs.filterNot(_._4).map {
             case (arg, _, liftedTypeArg, _) =>
-              val tEq = tq"_root_.scala.Predef.<:<[${liftedTypeArg.name}, $arg]"
+              val tEq = tq"${symbolOf[_ <:< _]}[${liftedTypeArg.name}, $arg]"
               ValDef(Modifiers(Flag.IMPLICIT), TermName(c.freshName("ev")), tEq, EmptyTree)
           }
           //params to strip from method signature because they are defined on


### PR DESCRIPTION
to unblock the community build.

Ref scala/scala#7350

which moved `<:<` out of `Predef`.